### PR TITLE
Add development environment tooling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/go:1.21
+
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
+    && npm install -g npm@latest \
+    && go install github.com/google/go-jsonnet/cmd/jsonnet@latest \
+    && go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest \
+    && go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest \
+    && go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest \
+    && npm cache clean --force \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/go/bin:${PATH}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "grafonnet-aws",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "./scripts/install.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ]
+    }
+  }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,16 @@ To install Grafonnet AWS with [jsonnet-bundler](https://github.com/jsonnet-bundl
 jb install github.com/slcp/grafonnet-aws/lib@main
 ```
 
+## Development
+
+To set up a development environment, use the helper script:
+
+```bash
+./scripts/install.sh
+```
+
+A VS Code dev container is provided in the `.devcontainer` directory with Go, Jsonnet, and jb preinstalled. The container runs the setup script automatically after creation.
+
 ## Usage
 
 ### Example Workflow

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
+go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+
+npm install


### PR DESCRIPTION
## Summary
- add setup script to install Jsonnet and npm dependencies
- provide Dev Container definition with preinstalled Go and Jsonnet tooling
- document development setup instructions

## Testing
- `npm test`
- `npm run generate:lib`


------
https://chatgpt.com/codex/tasks/task_e_688f447ab68c832ab108a5c12b1ee05f